### PR TITLE
hostname as a base param

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ By default, the `client_id` is set to a random UUID with `SecureRandom.uuid`
 
 ```ruby
 # Track a Pageview (all values optional)
-tracker.pageview(path: '/page-path', hostname: 'mysite.com', title: 'A Page!')
+tracker.pageview(path: '/page-path', title: 'A Page!')
 
 # Track an Event (all values optional)
 tracker.event(category: 'video', action: 'play', label: 'cars', value: 1)

--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -16,12 +16,14 @@ module Staccato
   # @param id [String, nil] the id provided by google, i.e., `UA-XXXXXX-Y`
   # @param client_id [String, Integer, nil] a unique id to track the session of
   #   an individual user
+  # @param hostname [String, Integer, nil] target website's hostname, needed
+  #   when using the same GA tracker id for more than one website
   # @return [Staccato::Tracker] a new tracker is returned
-  def self.tracker(id, client_id = nil)
+  def self.tracker(id, client_id = nil, hostname = nil)
     if id.nil?
       Staccato::NoopTracker.new
     else
-      Staccato::Tracker.new(id, client_id)
+      Staccato::Tracker.new(id, client_id, hostname)
     end
   end
 

--- a/lib/staccato/hit.rb
+++ b/lib/staccato/hit.rb
@@ -94,7 +94,7 @@ module Staccato
         'ni' => non_interactive,
         'sc' => session_control,
         't' => type.to_s
-      }
+      }.merge!(tracker.hostname.nil? ? {} : {'dh' => tracker.hostname})
     end
 
     # @private

--- a/lib/staccato/pageview.rb
+++ b/lib/staccato/pageview.rb
@@ -4,7 +4,6 @@ module Staccato
   class Pageview
     # Pageview field definitions
     FIELDS = {
-      hostname: 'dh',
       path: 'dp',
       title: 'dt'
     }

--- a/lib/staccato/tracker.rb
+++ b/lib/staccato/tracker.rb
@@ -4,18 +4,16 @@ module Staccato
   # 
   # @author Tony Pitale
   class Tracker
+    attr_reader :id, :hostname
+
     # sets up a new tracker
     # @param id [String] the GA tracker id
     # @param client_id [String, nil] unique value to track user sessions
-    def initialize(id, client_id = nil)
+    # @param hostname [String, nil] target website's hostname
+    def initialize(id, client_id = nil, hostname = nil)
       @id = id
       @client_id = client_id
-    end
-
-    # The tracker id for GA
-    # @return [String, nil]
-    def id
-      @id
+      @hostname = hostname
     end
 
     # The unique client id
@@ -28,7 +26,6 @@ module Staccato
     # 
     # @param options [Hash] options include:
     #   * path (optional) the path of the current page view
-    #   * hostname (optional) the hostname of the current page view
     #   * title (optional) the page title
     # @return [<Net::HTTPOK] the GA `/collect` endpoint always returns a 200
     def pageview(options = {})

--- a/spec/integration/noop_tracker_spec.rb
+++ b/spec/integration/noop_tracker_spec.rb
@@ -12,7 +12,7 @@ describe Staccato::NoopTracker do
 
   describe "#pageview" do
     before(:each) do
-      tracker.pageview(path: '/foobar', title: 'FooBar', hostname: 'mysite.com')
+      tracker.pageview(path: '/foobar', title: 'FooBar')
     end
 
     it 'does not track page path and page title' do

--- a/spec/integration/tracker_spec.rb
+++ b/spec/integration/tracker_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Staccato::Tracker do
   let(:uri) {Staccato.tracking_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
+  let(:tracker_with_hostname) {Staccato.tracker('UA-XXXX-Y', 555, 'mysite.com')}
   let(:response) {stub(:body => '', :status => 201)}
 
   before(:each) do
@@ -12,7 +13,7 @@ describe Staccato::Tracker do
 
   describe "#pageview" do
     before(:each) do
-      tracker.pageview(path: '/foobar', title: 'FooBar', hostname: 'mysite.com')
+      tracker.pageview(path: '/foobar', title: 'FooBar')
     end
 
     it 'tracks page path and page title' do
@@ -21,7 +22,6 @@ describe Staccato::Tracker do
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
         't' => 'pageview',
-        'dh' => 'mysite.com',
         'dp' => '/foobar',
         'dt' => 'FooBar'
       })

--- a/spec/lib/staccato/event_spec.rb
+++ b/spec/lib/staccato/event_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Staccato::Event do
 
   let(:tracker) {Staccato.tracker('UA-XXXX-Y', '555')}
+  let(:tracker_with_hostname) {Staccato.tracker('UA-XXXX-Y', '555', 'mysite.com')}
 
   context "with all options" do
     let(:event) do
@@ -51,7 +52,6 @@ describe Staccato::Event do
         :action => 'play',
         :label => 'cars',
         :value => 12,
-        :hostname => 'mysite.com',
         :path => '/foobar'
       })
     end
@@ -71,16 +71,26 @@ describe Staccato::Event do
   end
 
   context "with no options" do
-    let(:event) do
+    def event(tracker)
       Staccato::Event.new(tracker, {})
     end
 
     it 'has require params' do
-      event.params.should eq({
+      event(tracker).params.should eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
         't' => 'event'
+      })
+    end
+
+    it 'has require params with hostname' do
+      event(tracker_with_hostname).params.should eq({
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'event',
+        'dh' => 'mysite.com'
       })
     end
   end

--- a/spec/lib/staccato/pageview_spec.rb
+++ b/spec/lib/staccato/pageview_spec.rb
@@ -3,18 +3,14 @@ require 'spec_helper'
 describe Staccato::Pageview do
 
   let(:tracker) {Staccato.tracker('UA-XXXX-Y', '555')}
+  let(:tracker_with_hostname) {Staccato.tracker('UA-XXXX-Y', '555', 'mysite.com')}
 
   context "with all options" do
     let(:pageview) do
       Staccato::Pageview.new(tracker, {
-        :hostname => 'mysite.com',
         :path => '/foobar',
         :title => 'FooBar'
       })
-    end
-
-    it 'has a hostname' do
-      pageview.hostname.should eq('mysite.com')
     end
 
     it 'has a path' do
@@ -31,7 +27,6 @@ describe Staccato::Pageview do
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
         't' => 'pageview',
-        'dh' => 'mysite.com',
         'dp' => '/foobar',
         'dt' => 'FooBar'
       })
@@ -41,7 +36,6 @@ describe Staccato::Pageview do
   context "with extra options" do
     let(:pageview) do
       Staccato::Pageview.new(tracker, {
-        :hostname => 'mysite.com',
         :path => '/foobar',
         :title => 'FooBar',
         :action => 'play'
@@ -54,7 +48,6 @@ describe Staccato::Pageview do
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
         't' => 'pageview',
-        'dh' => 'mysite.com',
         'dp' => '/foobar',
         'dt' => 'FooBar'
       })
@@ -62,16 +55,26 @@ describe Staccato::Pageview do
   end
 
   context "with no options" do
-    let(:pageview) do
+    def pageview(tracker)
       Staccato::Pageview.new(tracker, {})
     end
 
     it 'has required params' do
-      pageview.params.should eq({
+      pageview(tracker).params.should eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
         't' => 'pageview'
+      })
+    end
+
+    it 'has required params with hostname' do
+      pageview(tracker_with_hostname).params.should eq({
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'pageview',
+        'dh' => 'mysite.com'
       })
     end
   end


### PR DESCRIPTION
In case you:
- send anonymous hits (eg. via client_id=555),
- AND use one ga tracking_id for more than one domain, eg. mysite.com and mysite.co.uk, you need to specify a hostname param for each hit you send.

Otherwise, in GA, the hit (no matter what kind of hit it is: event, transaction, pageview, etc) will be counted for each domain at the same time.

This commit fixes it by allowing to set a base param called 'hostname' which is then used for every hit we send.
