### PR TITLE
HTTP adapters

### DIFF
--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-require 'net/http'
 require 'forwardable'
 require 'securerandom'
 
@@ -16,12 +15,14 @@ module Staccato
   # @param id [String, nil] the id provided by google, i.e., `UA-XXXXXX-Y`
   # @param client_id [String, Integer, nil] a unique id to track the session of
   #   an individual user
+  # @params hit_options [Hash] options for use in all hits from this tracker
+  # @yield [Staccato::Tracker] the new tracker
   # @return [Staccato::Tracker] a new tracker is returned
   def self.tracker(id, client_id = nil, hit_options = {})
-    if id.nil?
-      Staccato::NoopTracker.new
-    else
-      Staccato::Tracker.new(id, client_id, hit_options)
+    klass = id.nil? ? Staccato::NoopTracker : Staccato::Tracker
+
+    klass.new(id, client_id, hit_options).tap do |tracker|
+      yield tracker if block_given?
     end
   end
 
@@ -33,7 +34,7 @@ module Staccato
   end
 
   # The tracking endpoint we use to submit requests to GA
-  def self.tracking_uri
+  def self.ga_collection_uri
     URI('http://www.google-analytics.com/collect')
   end
 end

--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -34,8 +34,9 @@ module Staccato
   end
 
   # The tracking endpoint we use to submit requests to GA
-  def self.ga_collection_uri
-    URI('http://www.google-analytics.com/collect')
+  def self.ga_collection_uri(ssl = false)
+    url = (ssl ? 'https://ssl' : 'http://www') + '.google-analytics.com/collect'
+    URI(url)
   end
 end
 

--- a/lib/staccato/adapter/faraday.rb
+++ b/lib/staccato/adapter/faraday.rb
@@ -1,0 +1,16 @@
+module Staccato
+  module Adapter
+    class Faraday # The Faraday Adapter
+      def initialize(uri)
+        @connection = Faraday.new(uri) do |faraday|
+          faraday.request  :url_encoded             # form-encode POST params
+          faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+        end
+      end
+
+      def post(params)
+        @connection.post(nil, params)
+      end
+    end
+  end
+end

--- a/lib/staccato/adapter/faraday.rb
+++ b/lib/staccato/adapter/faraday.rb
@@ -5,6 +5,8 @@ module Staccato
         @connection = Faraday.new(uri) do |faraday|
           faraday.request  :url_encoded             # form-encode POST params
           faraday.adapter  Faraday.default_adapter  # make requests with Net::HTTP
+
+          yield faraday if block_given?
         end
       end
 

--- a/lib/staccato/adapter/http.rb
+++ b/lib/staccato/adapter/http.rb
@@ -1,0 +1,13 @@
+module Staccato
+  module Adapter
+    class HTTP # The Ruby HTTP Library Adapter
+      def initialize(uri)
+        @uri = uri
+      end
+
+      def post(params)
+        ::HTTP.post(@uri, :form => params)
+      end
+    end
+  end
+end

--- a/lib/staccato/adapter/net_http.rb
+++ b/lib/staccato/adapter/net_http.rb
@@ -1,0 +1,17 @@
+require 'net/http'
+
+module Staccato
+  module Adapter
+    module Net
+      class HTTP # The net/http Standard Library Adapter
+        def initialize(uri)
+          @uri = uri
+        end
+
+        def post(params)
+          ::Net::HTTP.post_form(@uri, params)
+        end
+      end
+    end
+  end
+end

--- a/lib/staccato/tracker.rb
+++ b/lib/staccato/tracker.rb
@@ -4,6 +4,7 @@ module Staccato
   # 
   # @author Tony Pitale
   class Tracker
+    attr_writer :adapter
     attr_accessor :hit_defaults
 
     # sets up a new tracker
@@ -132,14 +133,22 @@ module Staccato
     # post the hit to GA collection endpoint
     # @return [Net::HTTPOK] the GA api always returns 200 OK
     def track(params={})
-      post(Staccato.tracking_uri, params)
+      post(params)
     end
 
     private
 
     # @private
-    def post(uri, params)
-      Net::HTTP.post_form(uri, params)
+    def post(params)
+      adapter.post(params)
+    end
+
+    def adapter
+      @adapter ||= begin
+        require 'staccato/adapter/net_http'
+
+        Staccato::Adapter::Net::HTTP.new(Staccato.ga_collection_uri)
+      end
     end
   end
 

--- a/spec/integration/measurement/checkout_option_spec.rb
+++ b/spec/integration/measurement/checkout_option_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::CheckoutOption do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/measurement/checkout_spec.rb
+++ b/spec/integration/measurement/checkout_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::Checkout do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/measurement/product_impression_spec.rb
+++ b/spec/integration/measurement/product_impression_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::ProductImpression do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/measurement/product_spec.rb
+++ b/spec/integration/measurement/product_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::Product do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/measurement/promotion_spec.rb
+++ b/spec/integration/measurement/promotion_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::Promotion do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/measurement/transaction_spec.rb
+++ b/spec/integration/measurement/transaction_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Measurement::Transaction do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 

--- a/spec/integration/noop_tracker_spec.rb
+++ b/spec/integration/noop_tracker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::NoopTracker do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker(nil)}
   let(:response) {stub(:body => '', :status => 201)}
 
@@ -16,7 +16,7 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track page path and page title' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
   end
 
@@ -31,7 +31,7 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track event category, action, label, value' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
   end
 
@@ -45,7 +45,7 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track social action, network, target' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
   end
 
@@ -58,7 +58,7 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track exception description and fatality' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
   end
 
@@ -73,7 +73,7 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track user timing category, variable, label, and time' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
   end
 
@@ -92,11 +92,11 @@ describe Staccato::NoopTracker do
     end
 
     it 'does not track user timing category, variable, label, and time' do
-      Net::HTTP.should have_received(:post_form).never
+      expect(Net::HTTP).to have_received(:post_form).never
     end
 
     it 'yields to the block' do
-      codez.should have_received(:test)
+      expect(codez).to have_received(:test)
     end
   end
 

--- a/spec/integration/tracker_spec.rb
+++ b/spec/integration/tracker_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Staccato::Tracker do
-  let(:uri) {Staccato.tracking_uri}
+  let(:uri) {Staccato.ga_collection_uri}
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 
@@ -16,7 +16,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks page path and page title' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -39,7 +39,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks event category, action, label, value' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -62,7 +62,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks social action, network, target' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -84,7 +84,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks exception description and fatality' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -107,7 +107,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks user timing category, variable, label, and time' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -135,7 +135,7 @@ describe Staccato::Tracker do
     end
 
     it 'tracks user timing category, variable, label, and time' do
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -148,7 +148,7 @@ describe Staccato::Tracker do
     end
 
     it 'yields to the block' do
-      codez.should have_received(:test)
+      expect(codez).to have_received(:test)
     end
   end
 
@@ -168,7 +168,7 @@ describe Staccato::Tracker do
       end
 
       it 'tracks the transaction values' do
-        Net::HTTP.should have_received(:post_form).with(uri, {
+        expect(Net::HTTP).to have_received(:post_form).with(uri, {
           'v' => 1,
           'tid' => 'UA-XXXX-Y',
           'cid' => '555',
@@ -199,7 +199,7 @@ describe Staccato::Tracker do
       end
 
       it 'tracks the item values' do
-        Net::HTTP.should have_received(:post_form).with(uri, {
+        expect(Net::HTTP).to have_received(:post_form).with(uri, {
           'v' => 1,
           'tid' => 'UA-XXXX-Y',
           'cid' => '555',
@@ -224,7 +224,7 @@ describe Staccato::Tracker do
     it 'tracks page path and default hostname' do
       tracker.pageview(path: '/foobar')
 
-      Net::HTTP.should have_received(:post_form).with(uri, {
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',

--- a/spec/lib/stacatto_spec.rb
+++ b/spec/lib/stacatto_spec.rb
@@ -7,13 +7,13 @@ describe Staccato do
     let(:tracker) {Staccato.tracker 'UA-XXXX-Y'}
 
     it 'has an assigned id' do
-      tracker.id.should eq('UA-XXXX-Y')
+      expect(tracker.id).to eq('UA-XXXX-Y')
     end
 
     it 'uses a uuid for the client_id' do
       SecureRandom.stubs(:uuid).returns("a-uuid")
 
-      tracker.client_id.should eq('a-uuid')
+      expect(tracker.client_id).to eq('a-uuid')
     end
 
   end

--- a/spec/lib/staccato/event_spec.rb
+++ b/spec/lib/staccato/event_spec.rb
@@ -15,23 +15,23 @@ describe Staccato::Event do
     end
 
     it 'has a category' do
-      event.category.should eq('video')
+      expect(event.category).to eq('video')
     end
 
     it 'has a action' do
-      event.action.should eq('play')
+      expect(event.action).to eq('play')
     end
 
     it 'has a label' do
-      event.label.should eq('cars')
+      expect(event.label).to eq('cars')
     end
 
     it 'has a value' do
-      event.value.should eq(12)
+      expect(event.value).to eq(12)
     end
 
     it 'has all params' do
-      event.params.should eq({
+      expect(event.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -57,7 +57,7 @@ describe Staccato::Event do
     end
 
     it 'has all params' do
-      event.params.should eq({
+      expect(event.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -76,7 +76,7 @@ describe Staccato::Event do
     end
 
     it 'has require params' do
-      event.params.should eq({
+      expect(event.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',

--- a/spec/lib/staccato/pageview_spec.rb
+++ b/spec/lib/staccato/pageview_spec.rb
@@ -14,19 +14,19 @@ describe Staccato::Pageview do
     end
 
     it 'has a hostname' do
-      pageview.hostname.should eq('mysite.com')
+      expect(pageview.hostname).to eq('mysite.com')
     end
 
     it 'has a path' do
-      pageview.path.should eq('/foobar')
+      expect(pageview.path).to eq('/foobar')
     end
 
     it 'has a title' do
-      pageview.title.should eq('FooBar')
+      expect(pageview.title).to eq('FooBar')
     end
 
     it 'has all params' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -49,7 +49,7 @@ describe Staccato::Pageview do
     end
 
     it 'has all params' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -67,7 +67,7 @@ describe Staccato::Pageview do
     end
 
     it 'has required params' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -85,7 +85,7 @@ describe Staccato::Pageview do
     end
 
     it 'has experiment id and variant' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -104,7 +104,7 @@ describe Staccato::Pageview do
     end
 
     it 'has session control param' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -125,7 +125,7 @@ describe Staccato::Pageview do
     end
 
     it 'has custom dimensions' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',
@@ -147,7 +147,7 @@ describe Staccato::Pageview do
     end
 
     it 'has custom dimensions' do
-      pageview.params.should eq({
+      expect(pageview.params).to eq({
         'v' => 1,
         'tid' => 'UA-XXXX-Y',
         'cid' => '555',

--- a/spec/lib/staccato/tracker_spec.rb
+++ b/spec/lib/staccato/tracker_spec.rb
@@ -15,11 +15,11 @@ describe Staccato::Tracker do
     end
 
     it "creates a new Pageview" do
-      Staccato::Pageview.should have_received(:new).with(tracker, path: '/foobar')
+      expect(Staccato::Pageview).to have_received(:new).with(tracker, path: '/foobar')
     end
 
     it "tracks on the Pageview" do
-      pageview.should have_received(:track!)
+      expect(pageview).to have_received(:track!)
     end
   end
 
@@ -34,11 +34,11 @@ describe Staccato::Tracker do
     end
 
     it "creates a new Event" do
-      Staccato::Event.should have_received(:new).with(tracker, category: 'video', action: 'play')
+      expect(Staccato::Event).to have_received(:new).with(tracker, category: 'video', action: 'play')
     end
 
     it "tracks on the Event" do
-      event.should have_received(:track!)
+      expect(event).to have_received(:track!)
     end
   end
 


### PR DESCRIPTION
* add ability to specify an adapter in block tracker configuration
* added some adapters for faraday (itself adapters), celluloid http, and defaults to net/http
* update rspec syntax from should to expect/to