### PR TITLE
Add track method to NoopTracker

### DIFF
--- a/lib/staccato/tracker.rb
+++ b/lib/staccato/tracker.rb
@@ -157,5 +157,8 @@ module Staccato
     # (see Tracker#transaction_item)
     def transaction_item(*)
     end
+
+    def track(*)
+    end
   end
 end

--- a/spec/integration/noop_tracker_spec.rb
+++ b/spec/integration/noop_tracker_spec.rb
@@ -99,4 +99,14 @@ describe Staccato::NoopTracker do
       codez.should have_received(:test)
     end
   end
+
+  describe "#track" do
+    before(:each) do
+      tracker.track
+    end
+
+    it 'does not send a post request' do
+      Net::HTTP.should have_received(:post_form).never
+    end
+  end
 end


### PR DESCRIPTION
Adds the `track` method to `NoopTracker`. This is useful when calling `Staccato::Pageview.new` (or `Event`, etc) directly, for instance when setting a custom dimension/metric : 

``` ruby
hit = Staccato::Pageview.new(tracker, '/sports-page-5')
hit.add_custom_dimension(19, 'Sports')
hit.add_custom_metric(2, 5)
hit.track!
```

Without the `track` method this fails on `hit.track!` when `tracker` is an instance of `NoopTracker` (e.g (presumably) during tests).
