### PR TITLE
Fix product impression prefix per documentation

### DIFF
--- a/lib/staccato/measurement/product_impression.rb
+++ b/lib/staccato/measurement/product_impression.rb
@@ -11,7 +11,7 @@ module Staccato
       # product impress prefix
       # @return [String]
       def prefix
-        'il' + list_index.to_s + 'pr' + index.to_s
+        'il' + list_index.to_s + 'pi' + index.to_s
       end
 
       # Product impression measurement options fields

--- a/spec/integration/measurement/product_impression_spec.rb
+++ b/spec/integration/measurement/product_impression_spec.rb
@@ -48,13 +48,13 @@ describe Staccato::Measurement::ProductImpression do
         'dp' => '/home',
         'dt' => 'Home Page',
         'il1nm' => 'Search Results',
-        'il1pr1id' => 'P12345',
-        'il1pr1nm' => 'T-Shirt',
-        'il1pr1br' => 'Your Brand',
-        'il1pr1ca' => 'Apparel',
-        'il1pr1va' => 'Purple',
-        'il1pr1pr' => 14.60,
-        'il1pr1ps' => 1
+        'il1pi1id' => 'P12345',
+        'il1pi1nm' => 'T-Shirt',
+        'il1pi1br' => 'Your Brand',
+        'il1pi1ca' => 'Apparel',
+        'il1pi1va' => 'Purple',
+        'il1pi1pr' => 14.60,
+        'il1pi1ps' => 1
       })
     end
   end


### PR DESCRIPTION
Product Impression prefix should be il<listIndex>pi<productIndex>
according to [the documentation]
(https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#il_pi_id)