### PR TITLE
Add the ability to add custom_dimensions and metrics to a measurement object

### DIFF
--- a/lib/staccato/hit.rb
+++ b/lib/staccato/hit.rb
@@ -135,11 +135,15 @@ module Staccato
     end
 
     # Add a measurement by its symbol name with options
-    # 
+    #
     # @param key [Symbol] any one of the measurable classes lookup key
-    # @param options [Hash] options for the measurement
+    # @param options [Hash or Object] for the measurement
     def add_measurement(key, options = {})
-      self.measurements << Measurement.lookup(key).new(options)
+      if options.is_a?(Hash)
+        self.measurements << Measurement.lookup(key).new(options)
+      else
+        self.measurements << options
+      end
     end
 
     # Measurements for this hit

--- a/lib/staccato/measurable.rb
+++ b/lib/staccato/measurable.rb
@@ -28,9 +28,58 @@ module Staccato
       ''
     end
 
+    # not all measurements allow custom dimensions
+    def custom_dimensions_allowed?
+      false
+    end
+
+    # not all measurements allow custom metrics
+    def custom_metrics_allowed?
+      false
+    end
+
     # collects the parameters from options for this measurement
     # @return [Hash]
     def params
+      {}.
+      merge!(measurable_params).
+      merge!(custom_dimensions).
+      merge!(custom_metrics).
+      reject {|_,v| v.nil?}
+    end
+
+    # Set a custom dimension value at an index
+    # @param dimension_index [Integer]
+    # @param value
+    def add_custom_dimension(dimension_index, value)
+      return unless custom_dimensions_allowed?
+      self.custom_dimensions["#{prefix}cd#{dimension_index}"] = value
+    end
+
+    # Custom dimensions for this measurable
+    # @return [Hash]
+    def custom_dimensions
+      @custom_dimensions ||= {}
+    end
+
+    # Set a custom metric value at an index
+    # @param metric_index [Integer]
+    # @param value
+    def add_custom_metric(metric_index, value)
+      return unless custom_metrics_allowed?
+      self.custom_metrics["#{prefix}cm#{metric_index}"] = value
+    end
+
+    # Custom metrics for this measurable
+    # @return [Hash]
+    def custom_metrics
+      @custom_metrics ||= {}
+    end
+
+    private
+
+    # @private
+    def measurable_params
       Hash[
         fields.map { |field,key|
           next if key.nil?

--- a/lib/staccato/measurable.rb
+++ b/lib/staccato/measurable.rb
@@ -28,13 +28,8 @@ module Staccato
       ''
     end
 
-    # not all measurements allow custom dimensions
-    def custom_dimensions_allowed?
-      false
-    end
-
-    # not all measurements allow custom metrics
-    def custom_metrics_allowed?
+    # not all measurements allow custom dimensions or metrics
+    def custom_fields_allowed?
       false
     end
 
@@ -52,7 +47,7 @@ module Staccato
     # @param dimension_index [Integer]
     # @param value
     def add_custom_dimension(dimension_index, value)
-      return unless custom_dimensions_allowed?
+      return unless custom_fields_allowed?
       self.custom_dimensions["#{prefix}cd#{dimension_index}"] = value
     end
 
@@ -66,7 +61,7 @@ module Staccato
     # @param metric_index [Integer]
     # @param value
     def add_custom_metric(metric_index, value)
-      return unless custom_metrics_allowed?
+      return unless custom_fields_allowed?
       self.custom_metrics["#{prefix}cm#{metric_index}"] = value
     end
 

--- a/lib/staccato/measurement/product.rb
+++ b/lib/staccato/measurement/product.rb
@@ -14,6 +14,16 @@ module Staccato
         'pr'+index.to_s
       end
 
+      # product allow custom dimensions
+      def custom_dimensions_allowed?
+        true
+      end
+
+      # product allow custom metrics
+      def custom_metrics_allowed?
+        true
+      end
+
       # Product measurement options fields
       FIELDS = {
         index: nil,

--- a/lib/staccato/measurement/product.rb
+++ b/lib/staccato/measurement/product.rb
@@ -14,13 +14,8 @@ module Staccato
         'pr'+index.to_s
       end
 
-      # product allow custom dimensions
-      def custom_dimensions_allowed?
-        true
-      end
-
-      # product allow custom metrics
-      def custom_metrics_allowed?
+      # product allow custom dimensions and metrics
+      def custom_fields_allowed?
         true
       end
 

--- a/lib/staccato/measurement/product_impression.rb
+++ b/lib/staccato/measurement/product_impression.rb
@@ -14,13 +14,8 @@ module Staccato
         'il' + list_index.to_s + 'pi' + index.to_s
       end
 
-      # product allow custom dimensions
-      def custom_dimensions_allowed?
-        true
-      end
-
-      # product allow custom metrics
-      def custom_metrics_allowed?
+      # product impression allow custom dimensions and metrics
+      def custom_fields_allowed?
         true
       end
 

--- a/lib/staccato/measurement/product_impression.rb
+++ b/lib/staccato/measurement/product_impression.rb
@@ -14,6 +14,16 @@ module Staccato
         'il' + list_index.to_s + 'pi' + index.to_s
       end
 
+      # product allow custom dimensions
+      def custom_dimensions_allowed?
+        true
+      end
+
+      # product allow custom metrics
+      def custom_metrics_allowed?
+        true
+      end
+
       # Product impression measurement options fields
       FIELDS = {
         index: nil,

--- a/spec/integration/measurement/product_impression_spec.rb
+++ b/spec/integration/measurement/product_impression_spec.rb
@@ -5,35 +5,43 @@ describe Staccato::Measurement::ProductImpression do
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 
+  let(:pageview) {
+    tracker.build_pageview({
+      path: '/home',
+      hostname: 'mystore.com',
+      title: 'Home Page'
+    })
+  }
+
+  let(:impression_list_options) {{
+    index: 1,
+    name: 'Search Results'
+  }}
+
+  let(:product_impression_options) {{
+    index: 1,
+    list_index: 1, # match the impression_list above
+    id: 'P12345',
+    name: 'T-Shirt',
+    category: 'Apparel',
+    brand: 'Your Brand',
+    variant: 'Purple',
+    position: 1,
+    price: 14.60
+  }}
+
+  let(:product_impression) { Staccato::Measurement::ProductImpression.new(product_impression_options) }
+
   before(:each) do
     SecureRandom.stubs(:uuid).returns('555')
     Net::HTTP.stubs(:post_form).returns(response)
   end
 
-  context 'a pageview with a transaction' do
-    let(:pageview) {
-      tracker.build_pageview({
-        path: '/home',
-        hostname: 'mystore.com',
-        title: 'Home Page'
-      })
-    }
-
-    let(:measurement_options) {{
-      index: 1,
-      list_index: 1, # match the impression_list above
-      id: 'P12345',
-      name: 'T-Shirt',
-      category: 'Apparel',
-      brand: 'Your Brand',
-      variant: 'Purple',
-      position: 1,
-      price: 14.60
-    }}
+  context 'a pageview with an List Impression' do
 
     before(:each) do
-      pageview.add_measurement(:impression_list, index: 1, name: 'Search Results')
-      pageview.add_measurement(:product_impression, measurement_options)
+      pageview.add_measurement(:impression_list, impression_list_options)
+      pageview.add_measurement(:product_impression, product_impression_options)
 
       pageview.track!
     end
@@ -58,4 +66,73 @@ describe Staccato::Measurement::ProductImpression do
       })
     end
   end
+
+  context 'with some custom dimensions' do
+
+    before(:each) do
+      pageview.add_measurement(:impression_list, impression_list_options)
+      product_impression.add_custom_dimension(1, 'Apple')
+      product_impression.add_custom_dimension(5, 'Samsung')
+      pageview.add_measurement(:product_impression, product_impression)
+
+      pageview.track!
+    end
+
+    it 'has custom dimensions data' do
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'pageview',
+        'dh' => 'mystore.com',
+        'dp' => '/home',
+        'dt' => 'Home Page',
+        'il1nm' => 'Search Results',
+        'il1pi1id' => 'P12345',
+        'il1pi1nm' => 'T-Shirt',
+        'il1pi1br' => 'Your Brand',
+        'il1pi1ca' => 'Apparel',
+        'il1pi1va' => 'Purple',
+        'il1pi1pr' => 14.60,
+        'il1pi1ps' => 1,
+        'il1pi1cd1' => 'Apple',
+        'il1pi1cd5' => 'Samsung'
+      })
+    end
+  end
+
+  context 'with some custom metrics' do
+
+    before(:each) do
+      pageview.add_measurement(:impression_list, impression_list_options)
+      product_impression.add_custom_metric(1, 43.20)
+      product_impression.add_custom_metric(3, 8)
+      pageview.add_measurement(:product_impression, product_impression)
+
+      pageview.track!
+    end
+
+    it 'has custom metric data' do
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'pageview',
+        'dh' => 'mystore.com',
+        'dp' => '/home',
+        'dt' => 'Home Page',
+        'il1nm' => 'Search Results',
+        'il1pi1id' => 'P12345',
+        'il1pi1nm' => 'T-Shirt',
+        'il1pi1br' => 'Your Brand',
+        'il1pi1ca' => 'Apparel',
+        'il1pi1va' => 'Purple',
+        'il1pi1pr' => 14.60,
+        'il1pi1ps' => 1,
+        'il1pi1cm1' => 43.20,
+        'il1pi1cm3' => 8
+      })
+    end
+  end
+
 end

--- a/spec/integration/measurement/product_spec.rb
+++ b/spec/integration/measurement/product_spec.rb
@@ -5,38 +5,40 @@ describe Staccato::Measurement::Product do
   let(:tracker) {Staccato.tracker('UA-XXXX-Y')}
   let(:response) {stub(:body => '', :status => 201)}
 
+  let(:event) {
+    tracker.build_event({
+      category: 'search',
+      action: 'click',
+      label: 'results',
+      product_action: 'click',
+      product_action_list: 'Search Results'
+    })
+  }
+
+  let(:product_options) {{
+    index: 1,
+    id: 'P12345',
+    name: 'T-Shirt',
+    category: 'Apparel',
+    brand: 'Your Brand',
+    variant: 'Purple',
+    quantity: 2,
+    position: 1,
+    price: 14.60,
+    coupon_code: 'ILUVTEES'
+  }}
+
+  let(:product) { Staccato::Measurement::Product.new(product_options) }
+
   before(:each) do
     SecureRandom.stubs(:uuid).returns('555')
     Net::HTTP.stubs(:post_form).returns(response)
   end
 
-  context 'a pageview with a transaction' do
-    let(:event) {
-      tracker.build_event({
-        category: 'search',
-        action: 'click',
-        label: 'results',
-        product_action: 'click',
-        product_action_list: 'Search Results'
-      })
-    }
+  context 'a pageview with an event' do
 
-    let(:measurement_options) {{
-      index: 1,
-      id: 'P12345',
-      name: 'T-Shirt',
-      category: 'Apparel',
-      brand: 'Your Brand',
-      variant: 'Purple',
-      quantity: 2,
-      position: 1,
-      price: 14.60,
-      coupon_code: 'ILUVTEES'
-    }}
-
-    before(:each) do
-      event.add_measurement(:product, measurement_options)
-
+    before do
+      event.add_measurement(:product, product_options)
       event.track!
     end
 
@@ -60,6 +62,77 @@ describe Staccato::Measurement::Product do
         'pr1ps' => 1,
         'pr1pr' => 14.60,
         'pr1cc' => 'ILUVTEES'
+      })
+    end
+
+  end
+
+  context "with some custom dimensions" do
+
+    before(:each) do
+      product.add_custom_dimension(1, 'Apple')
+      product.add_custom_dimension(5, 'Samsung')
+      event.add_measurement(:product, product)
+      event.track!
+    end
+
+    it 'has custom dimensions' do
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'event',
+        'ec' => 'search',
+        'ea' => 'click',
+        'el' => 'results',
+        'pa' => 'click',
+        'pal' => 'Search Results',
+        'pr1id' => 'P12345',
+        'pr1nm' => 'T-Shirt',
+        'pr1ca' => 'Apparel',
+        'pr1br' => 'Your Brand',
+        'pr1va' => 'Purple',
+        'pr1qt' => 2,
+        'pr1ps' => 1,
+        'pr1pr' => 14.60,
+        'pr1cc' => 'ILUVTEES',
+        'pr1cd1' => 'Apple',
+        'pr1cd5' => 'Samsung'
+      })
+    end
+  end
+
+  context "with some custom metrics" do
+
+    before do
+      product.add_custom_metric(1, 78)
+      product.add_custom_metric(3, 30.40)
+      event.add_measurement(:product, product)
+      event.track!
+    end
+
+    it 'has custom metrics' do
+      expect(Net::HTTP).to have_received(:post_form).with(uri, {
+        'v' => 1,
+        'tid' => 'UA-XXXX-Y',
+        'cid' => '555',
+        't' => 'event',
+        'ec' => 'search',
+        'ea' => 'click',
+        'el' => 'results',
+        'pa' => 'click',
+        'pal' => 'Search Results',
+        'pr1id' => 'P12345',
+        'pr1nm' => 'T-Shirt',
+        'pr1ca' => 'Apparel',
+        'pr1br' => 'Your Brand',
+        'pr1va' => 'Purple',
+        'pr1qt' => 2,
+        'pr1ps' => 1,
+        'pr1pr' => 14.60,
+        'pr1cc' => 'ILUVTEES',
+        'pr1cm1' => 78,
+        'pr1cm3' => 30.40
       })
     end
   end


### PR DESCRIPTION
Hi @tpitale! me again, following the comments on **PR #33** I propose this solution.

I only add the feature to the `Staccato::Measurement::Product` only for now, in order to check with you if this is what you are having in mind for this feature? 

I follow your logic in the `Staccato::Hit` module. Only add a **"control"** method because not all the Measurement object are allowed to handle custom dimensions or metrics. I was planning to `raise` and `exception` but I saw that you are not raising anything so I just return nil if the `custom_dimensions_allowed?` or `custom_metrics_allowed?` return `false`

Also fix the test in order to show this new feature the way you planned.
And now the `#add_measurement` method allow to receive an **object** or a **hash** (don't really like it the syntax I place in there, but it's literal at least :smile: )

All comments are welcome! and let me know If you want me to add all this stuff to the corresponding **objects**