### PR TITLE
Adds a default adapter method that returns Staccato::Adapter::Net::HTTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,11 +468,19 @@ end
 
 ### Validation Adapter ###
 
-The validation adapter takes the class of the request adapter you want to use (e.g. `Faraday` or `Net::HTTP`).
+The validation adapter sends hits to the debug endpoint, which responds with information about the validity of the hit.
 
 ```ruby
 tracker = Staccato.tracker('UA-XXXX-Y') do |c|
-  c.adapter = Staccato::Adapter::Validate.new(Staccato::Adapter::Net::HTTP)
+  c.adapter = Staccato::Adapter::Validate.new
+end
+```
+
+By default, the staccato `default_adapter` is used to send validation hits, but a different adapter can be used (e.g. `Faraday` or `Net::HTTP`).
+
+```ruby
+tracker = Staccato.tracker('UA-XXXX-Y') do |c|
+  c.adapter = Staccato::Adapter::Validate.new(Staccato::Adapter::HTTP)
 end
 ```
 

--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -38,6 +38,12 @@ module Staccato
     url = (ssl ? 'https://ssl' : 'http://www') + '.google-analytics.com/collect'
     URI(url)
   end
+
+  # The default adapter to use for sending hits
+  def self.default_adapter
+    require 'staccato/adapter/net_http'
+    Staccato::Adapter::Net::HTTP
+  end
 end
 
 require 'staccato/boolean_helpers'

--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -1,6 +1,7 @@
 require 'ostruct'
 require 'forwardable'
 require 'securerandom'
+require 'uri'
 
 require "staccato/version"
 

--- a/lib/staccato/adapter/validate.rb
+++ b/lib/staccato/adapter/validate.rb
@@ -1,7 +1,7 @@
 module Staccato
   module Adapter
     class Validate
-      def initialize(adapter)
+      def initialize(adapter = Staccato.default_adapter)
         @adapter = adapter.new URI('https://www.google-analytics.com/debug/collect')
       end
 

--- a/lib/staccato/tracker.rb
+++ b/lib/staccato/tracker.rb
@@ -144,11 +144,7 @@ module Staccato
     end
 
     def adapter
-      @adapter ||= begin
-        require 'staccato/adapter/net_http'
-
-        Staccato::Adapter::Net::HTTP.new(Staccato.ga_collection_uri)
-      end
+      @adapter ||= Staccato.default_adapter.new(Staccato.ga_collection_uri)
     end
   end
 


### PR DESCRIPTION
Also updated the readme this time!

Some thoughts: 
The validate adapter only works with adapters that take uri as their first argument, and precludes the possibility of passing more arguments. It's probably not a big deal, since `Validate` is just for convenience, and it's easy to make a more customizable adapter that posts to the debug endpoint. Maybe there's a better way to set it up, though.