### PR TITLE
Assign request to a response variable in Net::HTTP adaptor

### DIFF
--- a/lib/staccato/adapter/net_http.rb
+++ b/lib/staccato/adapter/net_http.rb
@@ -9,7 +9,7 @@ module Staccato
         end
 
         def post(params)
-          ::Net::HTTP.post_form(@uri, params)
+          response = ::Net::HTTP.post_form(@uri, params)
         end
       end
     end


### PR DESCRIPTION
I'm having problems reading the events information in Google Analytics. After spend a few days testing, I figured out that if I assign the request to a response variable, it works!

I found this solution trying to read the information from the Google Analytics response and I saw that when I use a variable it's working all the time.