### PR TITLE
Adds geographical_id as a global option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ Staccato::Hit::GLOBAL_OPTIONS.keys # =>
  :experiment_variant,
  :product_action,
  :product_action_list,
- :promotion_action]
+ :promotion_action,
+ :geographical_id]
 ```
 
 Boolean options like `anonymize_ip` will be converted from `true`/`false` into `1`/`0` as per the tracking API docs.

--- a/lib/staccato/hit.rb
+++ b/lib/staccato/hit.rb
@@ -71,7 +71,10 @@ module Staccato
       product_action_list: 'pal',
 
       # Promotion
-      promotion_action: 'promoa'
+      promotion_action: 'promoa',
+
+      # Location
+      geographical_id: 'geoid'
     }.freeze
 
     # Fields which should be converted to boolean for google


### PR DESCRIPTION
As described here: https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#geoid