### PR TITLE
Add data_source as a global option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Staccato::Hit::GLOBAL_OPTIONS.keys # =>
 
 [:anonymize_ip,
  :queue_time,
+ :data_source,
  :cache_buster,
  :user_id,
  :user_ip,
@@ -141,6 +142,8 @@ Staccato::Hit::GLOBAL_OPTIONS.keys # =>
 ```
 
 Boolean options like `anonymize_ip` will be converted from `true`/`false` into `1`/`0` as per the tracking API docs.
+
+The `data_source` option can take any value, but note that hits sent from other Google tools will have specific values.  Hits sent from analytics.js will have `data_source` set to `web`, and hits sent from one of the mobile SDKs will have `data_source` set to `app`.
 
 #### Custom Dimensions and Metrics ####
 

--- a/lib/staccato/hit.rb
+++ b/lib/staccato/hit.rb
@@ -22,6 +22,7 @@ module Staccato
     GLOBAL_OPTIONS = {
       anonymize_ip: 'aip', # boolean
       queue_time: 'qt', # integer
+      data_source: 'ds',
       cache_buster: 'z',
       user_id: 'uid', # a known user's id
 


### PR DESCRIPTION
As specified here:

https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#ds