### PR TITLE
Add adapter attribute for the NoopTracker

### DIFF
--- a/lib/staccato/tracker.rb
+++ b/lib/staccato/tracker.rb
@@ -173,6 +173,7 @@ module Staccato
   # A tracker which does no tracking
   #   Useful in testing
   class NoopTracker
+    attr_writer :adapter
     # (see Tracker#initialize)
     def initialize(id = nil, client_id = nil, hit_defaults = {}); end
 


### PR DESCRIPTION
I have a rails app what servers several domains so sometimes there is no GA Tracker ID and `NoopTracker` gets created.

I started to get exceptions like 

>  undefined method `adapter=' for #<Staccato::NoopTracker:0x0000000808d538>

I made a workaround:

```ruby
@tracker ||= Staccato.tracker(tracking_id, @user.id) do |t|
  if t.respond_to?(:adapter=)
    t.adapter = Staccato::Adapter::Proxy.new(...)
  end
end
``` 

Let's add `adapter` attribute for the `NoopTracker`.