### PR TITLE
CHG: support HTTP proxy in Staccato::Adapter::Net::HTTP

### DIFF
--- a/lib/staccato/adapter/net_http.rb
+++ b/lib/staccato/adapter/net_http.rb
@@ -4,12 +4,18 @@ module Staccato
   module Adapter
     module Net
       class HTTP # The net/http Standard Library Adapter
-        def initialize(uri)
+        def initialize(uri, proxy_host: nil, proxy_port: nil)
           @uri = uri
+          @proxy_host = proxy_host
+          @proxy_port = proxy_port
         end
 
         def post(params)
-          ::Net::HTTP.post_form(@uri, params)
+          if @proxy_host.present?
+            ::Net::HTTP.Proxy(@proxy_host, @proxy_port).post_form(@uri, params)
+          else
+            ::Net::HTTP.post_form(@uri, params)
+          end
         end
       end
     end

--- a/lib/staccato/adapter/net_http.rb
+++ b/lib/staccato/adapter/net_http.rb
@@ -11,7 +11,7 @@ module Staccato
         end
 
         def post(params)
-          if @proxy_host.present?
+          if @proxy_host
             ::Net::HTTP.Proxy(@proxy_host, @proxy_port).post_form(@uri, params)
           else
             ::Net::HTTP.post_form(@uri, params)

--- a/staccato.gemspec
+++ b/staccato.gemspec
@@ -18,6 +18,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
+  # for keyword arguments
+  spec.required_ruby_version = ">= 2.1.1"
+
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake", ">= 3.0.0"
   spec.add_development_dependency "rspec"


### PR DESCRIPTION
should I give up keyword arguments to support ruby below 2.1.1?