### PR TITLE
update ga_collection_uri endpoint

### DIFF
--- a/lib/staccato.rb
+++ b/lib/staccato.rb
@@ -36,7 +36,7 @@ module Staccato
 
   # The tracking endpoint we use to submit requests to GA
   def self.ga_collection_uri(ssl = false)
-    url = (ssl ? 'https://ssl' : 'http://www') + '.google-analytics.com/collect'
+    url = (ssl ? 'https://' : 'http://') + 'www.google-analytics.com/collect'
     URI(url)
   end
 


### PR DESCRIPTION
There is no 'https://ssl.google-analytics.com/collect' in this reference
https://developers.google.com/analytics/devguides/collection/protocol/v1/reference

I think that this reference is updated, so we should follow it

I am sorry if it is a misunderstanding